### PR TITLE
Fix bugs in IO utility and hash logging

### DIFF
--- a/src/com/hashing/all/Hash.java
+++ b/src/com/hashing/all/Hash.java
@@ -40,8 +40,8 @@ public enum Hash {
 			return sb.toString();
 
 		} catch (Exception e) {
-			System.out.println("Error calculado el Hash " + e.getMessage().toString());
-			e.getStackTrace();
+                        System.out.println("Error calculado el Hash " + e.getMessage().toString());
+                        e.printStackTrace();
 		}
 		return null;
 
@@ -52,13 +52,13 @@ public enum Hash {
 		try {
 			fis = new FileInputStream(new File("PATHtoFILE"));
 			System.out.println(Hash.MD5.checksum(new ByteArrayInputStream(IOUtils.toByteArray(fis))));
-		} catch (FileNotFoundException e) {
-			System.out.println("Error" + e.getMessage());
-			e.getStackTrace();
-		} catch (IOException e) {
-			System.out.println("Error" + e.getMessage());
-			e.getStackTrace();
-		}
+                } catch (FileNotFoundException e) {
+                        System.out.println("Error" + e.getMessage());
+                        e.printStackTrace();
+                } catch (IOException e) {
+                        System.out.println("Error" + e.getMessage());
+                        e.printStackTrace();
+                }
 	}
 
 }

--- a/src/com/io/file/ArrayOfBytesToFile.java
+++ b/src/com/io/file/ArrayOfBytesToFile.java
@@ -11,8 +11,8 @@ import java.nio.file.Paths;
 public class ArrayOfBytesToFile {
 	
 	private static final String UPLOAD_FOLDER = "data";
-	private static final String FILE_SEPARATOR = "file.separator";
-	private static final String USER_DIR = "file.separator";
+    private static final String FILE_SEPARATOR = "file.separator";
+    private static final String USER_DIR = "user.dir";
 
 	public static void main(String[] args) {
 		FileInputStream fileInputStream = null;
@@ -24,12 +24,15 @@ public class ArrayOfBytesToFile {
 			fileInputStream = new FileInputStream(file);
 			fileInputStream.read(bFile);
 			// save bytes[] into a file
-			writeBytesToFile(bFile,
-					System.getProperty(USER_DIR) + System.getProperty(FILE_SEPARATOR) + UPLOAD_FOLDER + "test1.txt");
-			writeBytesToFileClassic(bFile,
-					System.getProperty(USER_DIR) + System.getProperty(FILE_SEPARATOR) + UPLOAD_FOLDER + "test2.txt");
-			writeBytesToFileNio(bFile,
-					System.getProperty(USER_DIR) + System.getProperty(FILE_SEPARATOR) + UPLOAD_FOLDER + "test3.txt");
+                writeBytesToFile(bFile,
+                                System.getProperty(USER_DIR) + System.getProperty(FILE_SEPARATOR) + UPLOAD_FOLDER
+                                                + System.getProperty(FILE_SEPARATOR) + "test1.txt");
+                writeBytesToFileClassic(bFile,
+                                System.getProperty(USER_DIR) + System.getProperty(FILE_SEPARATOR) + UPLOAD_FOLDER
+                                                + System.getProperty(FILE_SEPARATOR) + "test2.txt");
+                writeBytesToFileNio(bFile,
+                                System.getProperty(USER_DIR) + System.getProperty(FILE_SEPARATOR) + UPLOAD_FOLDER
+                                                + System.getProperty(FILE_SEPARATOR) + "test3.txt");
 
 			System.out.println("Done");
 		} catch (IOException e) {


### PR DESCRIPTION
## Summary
- fix incorrect path constant in `ArrayOfBytesToFile`
- ensure path separators are inserted before generated files
- print stack traces when hash generation fails

## Testing
- `apt-get update -y`
- `apt-get install -y maven`
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_683f6ec2eb8c8332be1d176fb4523dbc