### PR TITLE
Fix typo in StringTest output

### DIFF
--- a/src/com/test/string/StringTest.java
+++ b/src/com/test/string/StringTest.java
@@ -35,7 +35,7 @@ public class StringTest {
 		int symbolsOnString = text.length();
 
 		System.out.println("Symbols on string - " + symbolsOnString);
-		System.out.println("Firt letter - " + text.charAt(0));
+                System.out.println("First letter - " + text.charAt(0));
 		System.out.println("Last letter - " + text.charAt(symbolsOnString - 1));
 
 		Random random = null;


### PR DESCRIPTION
## Summary
- correct a typo in `StringTest.getRandomText` output message

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f70447b74833281726fcf7e9a0e43