### PR TITLE
Fix buffer type in ConcatTest

### DIFF
--- a/src/com/test/string/ConcatTest.java
+++ b/src/com/test/string/ConcatTest.java
@@ -6,7 +6,7 @@ public class ConcatTest {
 	public static void main(String[] args) {
 
 		long startTime = System.currentTimeMillis();
-		StringBuilder sb = new StringBuilder("Java");
+                StringBuffer sb = new StringBuffer("Java");
 		for (int i = 0; i < 10000; i++) {
 			sb.append("Tpoint");
 		}


### PR DESCRIPTION
## Summary
- use `StringBuffer` for variable `sb`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f72d94ba48332a88d9a81b93af92c