### PR TITLE
Add generics and network examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The source code under `src/com/` is grouped in broad areas:
 - **connection** and **crud** – simple JDBC connectivity and CRUD operations.
 - **patterns** and **exceptions** – design pattern snippets and custom exception classes.
 - **laboratory** – assorted small OOP exercises and other experiments.
+- **generics** – small examples demonstrating Java generics.
+- **network** – simple networking utilities using `java.net` APIs.
 
 ## Running examples
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,16 +13,21 @@
 				</excludes>
 			</resource>
 		</resources>
-		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
-			</plugin>
-		</plugins>
+                <plugins>
+                        <plugin>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <version>3.8.0</version>
+                                <configuration>
+                                        <source>${java.version}</source>
+                                        <target>${java.version}</target>
+                                </configuration>
+                        </plugin>
+                        <plugin>
+                                <groupId>org.codehaus.mojo</groupId>
+                                <artifactId>exec-maven-plugin</artifactId>
+                                <version>3.1.0</version>
+                        </plugin>
+                </plugins>
 	</build>
 
 	<properties>

--- a/src/com/example/generics/Box.java
+++ b/src/com/example/generics/Box.java
@@ -1,0 +1,20 @@
+package com.example.generics;
+
+public class Box<T> {
+    private T value;
+
+    public Box() {
+    }
+
+    public Box(T value) {
+        this.value = value;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public void setValue(T value) {
+        this.value = value;
+    }
+}

--- a/src/com/example/generics/GenericDemo.java
+++ b/src/com/example/generics/GenericDemo.java
@@ -1,0 +1,9 @@
+package com.example.generics;
+
+public class GenericDemo {
+    public static void main(String[] args) {
+        Box<String> box = new Box<>();
+        box.setValue("Generics are powerful");
+        System.out.println("Box contains: " + box.getValue());
+    }
+}

--- a/src/com/example/network/HttpGetExample.java
+++ b/src/com/example/network/HttpGetExample.java
@@ -1,0 +1,41 @@
+package com.example.network;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class HttpGetExample {
+    public static void main(String[] args) {
+        String urlStr = "https://example.com";
+        HttpURLConnection connection = null;
+        BufferedReader reader = null;
+        try {
+            URL url = new URL(urlStr);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            int responseCode = connection.getResponseCode();
+            System.out.println("Response code: " + responseCode);
+
+            reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                System.out.println(line);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add exec-maven-plugin to build so examples run via Maven
- document new modules in README
- introduce simple generic Box class and demo
- add HttpURLConnection demo

## Testing
- `mvn -q exec:java -Dexec.mainClass=com.example.generics.GenericDemo` *(fails: plugin not downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_683f7b1c32bc833296fb3f3bf6d4c626